### PR TITLE
chore(deps): update `quote` 0.6 -> 1.0, `syn` 0.15 -> 1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,8 @@ keywords = ["struct", "field", "type", "name", "enum"]
 categories = ["rust-patterns"]
 
 [dependencies]
-quote = "0.6"
-syn = "0.15"
+quote = "1.0"
+syn = "1.0"
 heck = "0.3"
 
 [dev-dependencies]


### PR DESCRIPTION
This allows `field_types` to avoid adding unnecessary dependencies in a post-1.0 world for `syn` and `quote`. :)